### PR TITLE
Improve descriptions, help texts, error messages, etc

### DIFF
--- a/shuup_mailchimp/interface/base.py
+++ b/shuup_mailchimp/interface/base.py
@@ -50,11 +50,11 @@ class ShuupMailchimp(object):
 
     def _get_subscriber_hash(self, email):
         """
-        Get hash for subscriber email for updating list member
+        Get hash for subscriber email for updating list member.
 
         From Mailchimp API documentation: subscriber_hash is MD5
         hash of the lowercase version of the list member's email
-        address
+        address.
         """
         return hashlib.md5(email.lower().encode('utf-8')).hexdigest()
 
@@ -68,10 +68,10 @@ class ShuupMailchimp(object):
 
     def add_email_to_list(self, email, contact=None):
         """
-        Add given email to configured Mailchimp list
+        Add given email to configured Mailchimp list.
 
-        :param email: email to add list
-        :param contact: optional associated Shuup contact
+        :param email: email to add list.
+        :param contact: optional associated Shuup contact.
         """
         if not self._is_enabled():
             return
@@ -108,9 +108,9 @@ class ShuupMailchimp(object):
             MailchimpStatusLog.change_status(email, MailchimpStatus.SUBSCRIBED)
             return mailchimp_contact
         except (requests.RequestException, requests.ConnectionError):
-            logger.exception("Failed to send data to MailChimp")
+            logger.exception("Error! Failed to send data to MailChimp.")
             mailchimp_contact.add_log_entry(
-                "Unexpected error: Couldn't send email to list.", "client_error", LogEntryKind.ERROR)
+                "Error! Unexpected error: Couldn't send email to list.", "client_error", LogEntryKind.ERROR)
 
     def remove_email_from_list(self, email):
         if not self._is_enabled():
@@ -140,6 +140,6 @@ class ShuupMailchimp(object):
             MailchimpStatusLog.change_status(email, MailchimpStatus.UNSUBSCRIBED)
             return mailchimp_contact
         except (requests.RequestException, requests.ConnectionError):
-            logger.exception("Failed to send data to MailChimp")
+            logger.exception("Error! Failed to send data to MailChimp.")
             mailchimp_contact.add_log_entry(
-                "Unexpected error: Couldn't send email to list.", "client_error", LogEntryKind.ERROR)
+                "Error! Unexpected error: Couldn't send email to list.", "client_error", LogEntryKind.ERROR)

--- a/shuup_mailchimp/interface/utils/testing.py
+++ b/shuup_mailchimp/interface/utils/testing.py
@@ -37,7 +37,7 @@ def test_interface_with_response(request):
 
     if not interface_test(shop):
         configuration.set(shop, MC_CHECK_SUCCESS, False)
-        return JsonResponse({"message": _("Testing configuration failed")}, status=400)
+        return JsonResponse({"message": _("Testing configuration failed.")}, status=400)
 
     configuration.set(shop, MC_CHECK_SUCCESS, True)
-    return JsonResponse({"message": _("Configuration test successful")})
+    return JsonResponse({"message": _("Configuration test was successful.")})

--- a/shuup_mailchimp/templates/shuup_mailchimp/admin/connect.jinja
+++ b/shuup_mailchimp/templates/shuup_mailchimp/admin/connect.jinja
@@ -57,7 +57,7 @@
 (function() {
     $("#mailchimp-submit").on("click", function(e){
         e.preventDefault();
-        const defaultError = "{% trans %}Unexpected error happened please try again.{% endtrans %}";
+        const defaultError = "{% trans %}Unexpected error happened, please try again.{% endtrans %}";
         var url = $(this).data("url");
         var data = {};
         $.each($("#mailchimp-settings").serializeArray(), function() {

--- a/shuup_mailchimp/views.py
+++ b/shuup_mailchimp/views.py
@@ -19,7 +19,7 @@ def subscribe_newsletter(request):
             email = request.POST.get("email")
             validate_email(email)
             add_email_to_list(request.shop, email)
-            return JsonResponse({"message": "success"}, status=200)
+            return JsonResponse({"message": "Success!"}, status=200)
         except ValidationError:
-            return JsonResponse({"message": "error"}, status=400)
-    return JsonResponse({"message": "error"}, status=400)
+            return JsonResponse({"message": "Error!"}, status=400)
+    return JsonResponse({"message": "Error!"}, status=400)


### PR DESCRIPTION
This is part of a big update to improve various texts in Shuup.

A lot of changes, touching almost every individual Shuup project's repo.

There are too many changes to try to describe them separately, but the 
main ones are:
1. Improve `help_text` descriptions. Fix typos, rewrite and change, 
write new ones.
2. Change some of the model field names (for example rename 
`available_from` -> `available_since`; `available_to` `available_until` 
- this is in a separate commit).
3. Improve some of the documentation.
4. Improve some in-code-comments.
5. Improve `settings.py` files. It's now clearer what each option does.
6. Change some of the naming.
7. Change the error/message system.

The main Shuup repo's Merge Request is here: 
https://github.com/shuup/shuup/pull/2113 (with a reasoning behind 
changes).